### PR TITLE
fix: (eval):2: parse error near `<'

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,7 @@
 
 get_maven_versions() {
     # super clumsy regex to locate all Maven version tags on their history page
-    version=".*<td>(<b>)?([0-9]\.[0-9](\.[0-9])?(-.*)?)(</b>)?</td>.*"
+    version=".*<td>(<b>)?([0-9]\.[0-9](\.[0-9])?(-[^<]*)?)(</b>)?</td>.*"
 
     # iterate all lines coming back from the Maven release history
     for line in $(curl -s https://maven.apache.org/docs/history.html); do


### PR DESCRIPTION
when I type this `mise install maven@`, and then type <kbd>tab</kbd> to try to install a maven version. It doesn't show the versions of maven, but I get a error:

```
(eval):2: parse error near `<'
```

It seems that the problem occurs to `list-all`. And then I run this script and this result appears in the output:

```
4.0.0-beta-4</b>
```
which is caused by wrong regular expression.